### PR TITLE
Swift3cleanup

### DIFF
--- a/Sources/Array.swift
+++ b/Sources/Array.swift
@@ -15,12 +15,13 @@
  */
 
 extension Array where Element: Equatable {
+    
     func begins(with: [Element]) -> Bool {
         if with.count > self.count {
             return false
         }
 
-        for x in 0..<with.count {
+        for x in with.indices {
             if self[x] != with[x] {
                 return false
             }
@@ -28,9 +29,11 @@ extension Array where Element: Equatable {
 
         return true
     }
+    
 }
 
 extension Array: Equatable, Hashable {
+    
     public var hashValue: Int {
         return String(describing: self).hashValue
     }
@@ -38,4 +41,5 @@ extension Array: Equatable, Hashable {
     public static func == (lhs: Array<Element>, rhs: Array<Element>) -> Bool {
         return lhs.hashValue == rhs.hashValue
     }
+    
 }

--- a/Sources/Date.swift
+++ b/Sources/Date.swift
@@ -39,6 +39,7 @@ private func localTimeOffset() -> String {
  }
 
 extension Date {
+    
     // rfc3339 w fractional seconds w/ time offset
     init?(rfc3339String: String, fractionalSeconds: Bool = true, localTime: Bool = false) {
         var dateStr = rfc3339String
@@ -47,12 +48,8 @@ extension Date {
         if localTime {
             dateStr += localTimeOffset()
         }
-
-        if fractionalSeconds {
-            dateFormatter = rfc3339fractionalformatter
-        } else {
-            dateFormatter = rfc3339formatter
-        }
+        
+        dateFormatter = fractionalSeconds ? rfc3339fractionalformatter : rfc3339formatter
 
         if let d = dateFormatter.date(from: dateStr) {
             self.init(timeInterval: 0, since: d)
@@ -64,4 +61,5 @@ extension Date {
     func rfc3339String() -> String {
         return rfc3339fractionalformatter.string(from: self)
     }
+    
 }

--- a/Sources/Helpers.swift
+++ b/Sources/Helpers.swift
@@ -23,7 +23,7 @@ class ArrayWrapper: SetValueProtocol {
         self.array = array
     }
 
-    public func setValue(key: [String], value: Any) {
+    public func set(value: Any, for: [String]) {
         array.append(value)
     }
 }
@@ -38,8 +38,8 @@ class ArrayWrapper: SetValueProtocol {
 */
 func checkAndSetArray<T: SetValueProtocol>(check: [Any], key: [String], out: inout T) throws {
     // allow empty arrays
-    if check.count == 0 {
-        out.setValue(key: key, value: check)
+    if check.isEmpty {
+        out.set(value: check, for: key)
         return
     }
 
@@ -47,37 +47,37 @@ func checkAndSetArray<T: SetValueProtocol>(check: [Any], key: [String], out: ino
     switch check[0] {
         case is Int:
             if let typedArray = check as? [Int] {
-                out.setValue(key: key, value: typedArray)
+                out.set(value: typedArray, for: key)
             } else {
                 throw TomlError.MixedArrayType("Int")
             }
         case is Double:
             if let typedArray = check as? [Double] {
-                out.setValue(key: key, value: typedArray)
+                out.set(value: typedArray, for: key)
             } else {
                 throw TomlError.MixedArrayType("Double")
             }
         case is String:
             if let typedArray = check as? [String] {
-                out.setValue(key: key, value: typedArray)
+                out.set(value: typedArray, for: key)
             } else {
                 throw TomlError.MixedArrayType("String")
             }
         case is Bool:
             if let typedArray = check as? [Bool] {
-                out.setValue(key: key, value: typedArray)
+                out.set(value: typedArray, for: key)
             } else {
                 throw TomlError.MixedArrayType("Bool")
             }
         case is Date:
             if let typedArray = check as? [Date] {
-                out.setValue(key: key, value: typedArray)
+                out.set(value: typedArray, for: key)
             } else {
                 throw TomlError.MixedArrayType("Date")
             }
         default:
             // array of arrays leave as any
-            out.setValue(key: key, value: check)
+            out.set(value: check, for: key)
     }
 }
 
@@ -110,7 +110,7 @@ func getKeyPathFromTable(tokens: [Token]) -> [String] {
 }
 
 func consumeTableIdentifierTokens(tableTokens: inout [Token], tokens: inout [Token]) {
-    while tokens.count > 0 {
+    while !tokens.isEmpty {
         let nestedToken = tokens[0]
         tableTokens.append(nestedToken)
         tokens.remove(at: 0)
@@ -168,7 +168,7 @@ func getTableTokens(keyPath: [String], tokens: inout [Token]) -> [Token] {
 
 func extractTableTokens(tokens: inout [Token], inline: Bool = false) -> [Token] {
     var tableTokens = [Token]()
-    while tokens.count > 0 {
+    while !tokens.isEmpty {
         let tableToken = tokens[0]
 
         if inline {

--- a/Sources/Lexer.swift
+++ b/Sources/Lexer.swift
@@ -41,8 +41,8 @@ class Lexer {
             // check content against evaluators to produce tokens
             for evaluator in grammar[stack.last!]! {
                 if let e = try evaluator.evaluate(content) {
-                    if e.token != nil {
-                        tokens.append(e.token!)
+                    if let t = e.token {
+                        tokens.append(t)
                     }
 
                     // should we pop the stack?
@@ -51,8 +51,8 @@ class Lexer {
                     }
 
                     // should we push onto the stack?
-                    if evaluator.push != nil {
-                        stack = stack + evaluator.push!
+                    if let pushItmes = evaluator.push {
+                        stack = stack + pushItmes
                     }
 
                     content = content.substring(from: e.index)
@@ -67,4 +67,5 @@ class Lexer {
         }
         return tokens
     }
+    
 }

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -62,7 +62,7 @@ class Parser {
         // Convert tokens to values in the Toml
         var myTokens = tokens
 
-        while myTokens.count > 0 {
+        while !myTokens.isEmpty {
             let token = myTokens.remove(at: 0)
             if case .Key(let val) = token {
                 currentKey = val
@@ -82,7 +82,7 @@ class Parser {
     private func parse(tokens: inout [Token]) throws -> [Any] {
         var array: [Any] = [Any]()
 
-        while tokens.count > 0 {
+        while !tokens.isEmpty {
             let token = tokens.remove(at: 0)
             switch token {
                 case .Identifier(let val):
@@ -130,7 +130,7 @@ class Parser {
             throw TomlError.DuplicateKey(String(describing: key))
         }
 
-        toml.setValue(key: key, value: currToken.value)
+        toml.set(value: currToken.value, for: key)
     }
 
     /**
@@ -146,7 +146,7 @@ class Parser {
         // clear out the keyPath
         keyPath.removeAll()
 
-        while tokens.count > 0 {
+        while !tokens.isEmpty {
             let subToken = tokens.remove(at: 0)
             if case .TableEnd = subToken {
                 if keyPath.count < 1 {
@@ -184,7 +184,7 @@ class Parser {
         // clear out the keyPath
         keyPath.removeAll()
 
-        tableLoop: while tokens.count > 0 {
+        tableLoop: while !tokens.isEmpty {
             let subToken = tokens.remove(at: 0)
             if case .TableArrayEnd = subToken {
                 if keyPath.count < 1 {
@@ -198,11 +198,11 @@ class Parser {
                     let tableParser = Parser()
                     try tableParser.parse(tokens: tableTokens)
                     arr.append(tableParser.toml)
-                    toml.setValue(key: keyPath, value: arr)
+                    toml.set(value: arr, for: keyPath)
                 } else {
                     let tableParser = Parser()
                     try tableParser.parse(tokens: tableTokens)
-                    toml.setValue(key: keyPath, value: [tableParser.toml])
+                    toml.set(value: [tableParser.toml], for: keyPath)
                 }
                 break tableLoop
             } else if case .Identifier(let val) = subToken {
@@ -243,8 +243,8 @@ class Parser {
         myKeyPath.append(currentKey)
 
         // allow empty arrays
-        if arr.count == 0 {
-            toml.setValue(key: myKeyPath, value: arr)
+        if arr.isEmpty {
+            toml.set(value: arr, for: myKeyPath)
             return
         }
 

--- a/Sources/Regex.swift
+++ b/Sources/Regex.swift
@@ -17,18 +17,20 @@
 import Foundation
 
 var expressions = [String: NSRegularExpression]()
+
 extension String {
     func match(_ regex: String, options: NSRegularExpression.Options = []) -> String? {
         let expression: NSRegularExpression
-        if let exists = expressions[regex] {
-            expression = exists
+        
+        if let cachedRegexp = expressions[regex] {
+            expression = cachedRegexp
         } else {
             expression = try! NSRegularExpression(pattern: "^\(regex)", options: options)
             expressions[regex] = expression
         }
-
+        
         let range = expression.rangeOfFirstMatch(in: self, options: [],
-            range: NSMakeRange(0, self.utf16.count))
+            range: NSMakeRange(0, self.characters.count))
         if range.location != NSNotFound {
             return (self as NSString).substring(with: range)
         }

--- a/Sources/Tokens.swift
+++ b/Sources/Tokens.swift
@@ -91,11 +91,11 @@ enum Token: Hashable {
             return nil
         }
     }
-
-}
-
-func == (lhs: Token, rhs: Token) -> Bool {
-    return lhs.hashValue == rhs.hashValue
+    
+    static func == (lhs: Token, rhs: Token) -> Bool {
+        return lhs.hashValue == rhs.hashValue
+    }
+    
 }
 
 typealias TokenGenerator = (String) throws -> Token?

--- a/Sources/Toml.swift
+++ b/Sources/Toml.swift
@@ -36,7 +36,7 @@ public enum TomlError: Error {
 }
 
 protocol SetValueProtocol {
-    mutating func setValue(key: [String], value: Any)
+    mutating func set(value: Any, for key: [String])
 }
 
 /**
@@ -104,7 +104,7 @@ public class Toml: CustomStringConvertible, SetValueProtocol {
         - Parameter key: Array of strings
         - Parameter value: Value to set
     */
-    public func setValue(key: [String], value: Any) {
+    public func set(value: Any, for key: [String]) {
         let path = String(describing: key)
         keyNames.insert(key)
         data[path] = value
@@ -364,7 +364,7 @@ public class Toml: CustomStringConvertible, SetValueProtocol {
             var keyArray = keyName
             if keyArray.begins(with: path) {
                 keyArray.removeSubrange(0..<path.count)
-                constructedTable.setValue(key: keyArray, value: self.value(keyName)!)
+                constructedTable.set(value: self.value(keyName)!, for: keyArray)
             }
         }
 
@@ -373,7 +373,7 @@ public class Toml: CustomStringConvertible, SetValueProtocol {
             var tableArray = tableName
             if tableArray.begins(with: path) {
                 tableArray.removeSubrange(0..<path.count)
-                if tableArray.count != 0 {
+                if !tableArray.isEmpty {
                     constructedTable.setTable(key: tableArray)
                 }
             }


### PR DESCRIPTION
# Things i have done:
- [X] Equatable conformance == method moved to a static member like Swift3 convention.
- [X] Protocol `SetValueProtocol` method ranamed from `func setValue(key: , value: )` --> `func set(value:, for:)`
- [X] used `XYZ.isEmpty` rather than `XYZ.count == 0`.  Reasons: Slight gain of performance. More readable and to avoid playing with raw numbers when possible.
- [X] Some minor code cleanup.
## Things i would like to discuss
- Initially regexp match was using `NSMakeRange(0, self.utf16.count)`. I changed it to `self.characters.count` which is canonical but more unicode aware. Was it intentional to use UTF16 or it just happened to be that way.
