### PR TITLE
Optimize lookup performance by avoiding String(describing:_)

### DIFF
--- a/Sources/Path.swift
+++ b/Sources/Path.swift
@@ -14,32 +14,39 @@
  * limitations under the License.
  */
 
-extension Array where Element: Equatable {
-    
-    func begins(with: [Element]) -> Bool {
-        if with.count > self.count {
+/**
+    Abstraction for TOML key paths
+*/
+public struct Path: Hashable, Equatable {
+    internal(set) public var components: [String]
+
+    init(_ components: [String]) {
+        self.components = components
+    }
+
+    func begins(with: [String]) -> Bool {
+        if with.count > components.count {
             return false
         }
 
         for x in with.indices {
-            if self[x] != with[x] {
+            if components[x] != with[x] {
                 return false
             }
         }
 
         return true
     }
-    
-}
 
-extension Array: Equatable, Hashable {
-    
     public var hashValue: Int {
-        return String(describing: self).hashValue
+        return components.reduce(0, { $0 ^ $1.hashValue })
     }
 
-    public static func == (lhs: Array<Element>, rhs: Array<Element>) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+    public static func == (lhs: Path, rhs: Path) -> Bool {
+        return lhs.components == rhs.components
     }
-    
+
+    static func + (lhs: Path, rhs: Path) -> Path {
+        return Path(lhs.components + rhs.components)
+    }
 }

--- a/Sources/Serialize.swift
+++ b/Sources/Serialize.swift
@@ -19,8 +19,8 @@ import Foundation
 /**
     Get list of top level keys and optionally sort
 */
-private func filterKeys(keys: Set<[String]>) -> [String] {
-    var myKeys = keys.filter({ $0.count == 1}).map({ $0.last! })
+private func filterKeys(keys: Set<Path>) -> [String] {
+    var myKeys = keys.filter({ $0.components.count == 1}).map({ $0.components.first! })
     myKeys.sort()
     return myKeys
 }
@@ -59,7 +59,7 @@ private func serializeTable(toml: Toml) -> [String] {
         // get table title
         var titleParts = [tableName]
         if let prefixPath = toml.prefixPath {
-            titleParts = prefixPath + [tableName]
+            titleParts = prefixPath.components + [tableName]
         }
         let title = titleParts.map(quoted).joined(separator: ".")
 

--- a/Tests/TomlTests/TomlTests.swift
+++ b/Tests/TomlTests/TomlTests.swift
@@ -48,7 +48,7 @@ class TomlTests: XCTestCase {
         XCTAssertFalse(actual.hasTable("non-existant-table"))
         XCTAssertFalse(actual.hasKey("inline_table", "4"))
 
-        XCTAssertEqual(actual.array("array"), [1, 2, 3])
+        XCTAssertEqual(actual.array("array") ?? [], [1, 2, 3])
     }
 
     func testSerialize() {
@@ -231,7 +231,7 @@ class TomlTests: XCTestCase {
     func testCommentsEverywhere() {
         let actual = try! Toml(contentsOfFile: "Tests/TomlTests/comments-everywhere.toml")
         XCTAssertEqual(actual.int("group", "answer"), 42)
-        XCTAssertEqual(actual.array("group", "more"), [42, 42])
+        XCTAssertEqual(actual.array("group", "more") ?? [], [42, 42])
     }
 
     func testDatetime() {
@@ -247,7 +247,7 @@ class TomlTests: XCTestCase {
         let actual = try! Toml(contentsOfFile: "Tests/TomlTests/example.toml")
         XCTAssertEqual(actual.date("best-day-ever"), Date(rfc3339String: "1987-07-05T17:45:00.0Z")!)
         XCTAssertFalse(actual.bool("numtheory", "boring")!)
-        XCTAssertEqual(actual.array("numtheory", "perfection"), [6, 28, 496])
+        XCTAssertEqual(actual.array("numtheory", "perfection") ?? [], [6, 28, 496])
     }
 
     func testFloat() {


### PR DESCRIPTION
Introduces `struct Path` as an internal abstraction for key paths, to replace `[String]`. This is required to keep the key paths `Hashable` without using `String(describing:)`.

Basic lookup benchmarks (I used the `testTomlExample` test 10000 times in a loop, excluding parsing), indicate the following speed increase:
- in debug mode: ~27s → ~20s = 25% less time
- in release mode: ~23s → ~14s = 40% less time
